### PR TITLE
How to build gcp-lb-tags. Fixed Mac cacerts path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You also need to create a client in your UAA server for harbor:
 . ../envs/cicd/envs.sh
 uaac client add ${HARBOR_UAA_CLIENT_ID} --scope openid \
   --authorized_grant_types client_credentials,password,refresh_token \
-  --redirect_uri 'https://${HARBOR_DNS}  https://${HARBOR_DNS}/*' \
+  --redirect_uri "https://${HARBOR_DNS}  https://${HARBOR_DNS}/*" \
   --secret "${HARBOR_UAA_CLIENT_SECRET}" \
   --authorities clients.read,clients.secret,uaa.resource,scim.write,openid,scim.read
 ```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You also need to create a client in your UAA server for harbor:
 . ../envs/cicd/envs.sh
 uaac client add ${HARBOR_UAA_CLIENT_ID} --scope openid \
   --authorized_grant_types client_credentials,password,refresh_token \
-  --redirect_uri 'https://${HARBOR_URL}  https://${HARBOR_URL}/*' \
+  --redirect_uri 'https://${HARBOR_DNS}  https://${HARBOR_DNS}/*' \
   --secret "${HARBOR_UAA_CLIENT_SECRET}" \
   --authorities clients.read,clients.secret,uaa.resource,scim.write,openid,scim.read
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ wait for cluster to be ready...
 
 ```bash
 . ../envs/cicd/envs.sh
-
+./scripts/configure-lb.sh
 ```
 
 Set up DNS for the created LB to your external hostname used above.
@@ -149,7 +149,7 @@ Harbor will autogenerate certificates for notary, but it will regenerate them ev
 
 ```bash
 kubectl create namespace harbor
-kubectl -n harbor apply -f ./resources/harbor/notary-certs-secret.yaml
+kubectl -n harbor apply -f ./envs/cicd/harbor/notary-certs-secret.yaml
 ```
 
 Harbor also needs your UAA server's CA Cert. You can create a secret for it like so:
@@ -180,6 +180,7 @@ kubectl create namespace spinnaker
 ```
 
 In order for Spinnaker to trust UAA's CA CERT we need to construct a new java cert store that includes our UAA cert:
+Note: If you're on a Mac, you'll need to run replace `/etc/ssl/certs/java/cacerts` with `$(/usr/libexec/java_home)/lib/security/cacerts`
 
 ```bash
 . ./envs/cicd/envs.sh

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ wait for cluster to be ready...
 
 ### Load env and create LB
 
+The `configure-lb.sh` script uses a binary called `gcp-lb-tags`. To build the binary, clone [gcp-lb-tags](https://github.com/paulczar/gcp-lb-tags) and run `go build`. Move the resulting `gcp-lb-tags` binary to this directory, or add it to your PATH.
+
 ```bash
 . ../envs/cicd/envs.sh
 ./scripts/configure-lb.sh
@@ -180,7 +182,7 @@ kubectl create namespace spinnaker
 ```
 
 In order for Spinnaker to trust UAA's CA CERT we need to construct a new java cert store that includes our UAA cert:
-Note: If you're on a Mac, you'll need to run replace `/etc/ssl/certs/java/cacerts` with `$(/usr/libexec/java_home)/lib/security/cacerts`
+Note: If you're on a Mac, you'll need to run replace `/etc/ssl/certs/java/cacerts` with `$(/usr/libexec/java_home)/jre/lib/security/cacerts`
 
 ```bash
 . ./envs/cicd/envs.sh

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -45,6 +45,7 @@ releases:
           serviceAccountSecret: {{ requiredEnv "EXTERNAL_DNS_SECRET"}}
         domainFilters:
           - {{ requiredEnv "EXTERNAL_DNS_DOMAIN" }}
+        txtOwnerId: "cicd"
         resources:
           limits:
             memory: 50Mi
@@ -152,7 +153,7 @@ releases:
   - name: concourse
     namespace: concourse
     chart: stable/concourse
-    version: 6.2.2
+    version: 8.1.0
     values:
       - nameOverride: concourse
         fullnameOverride: concourse
@@ -166,7 +167,7 @@ releases:
               oidc:
                 enabled: true
                 displayName: "PKS Auth"
-                issuer: {{ requiredEnv "UAA_URL" }}/oauth/token #
+                issuer: {{ requiredEnv "UAA_URL" }}/oauth/token
                 useCaCert: true
                 scope: "openid,roles,uaa.user"
                 userNameKey: user_name


### PR DESCRIPTION
Added info on how to build gcp-lb-tags before executing ./scripts/configure-lb.sh.
Also added "/jre" into the path to cacerts for Macs.